### PR TITLE
Fixing vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE"
   },
   "devDependencies": {
-    "bootstrap": "^3.3.7",
+    "bootstrap": "^4.1.2",
     "browser-sync": "^2.13.0",
     "font-awesome": "^4.6.3",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Remediation
Upgrade bootstrap to version 4.1.2 or later. For example:

"dependencies": {
  "bootstrap": ">=4.1.2"
}
or…
"devDependencies": {
  "bootstrap": ">=4.1.2"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2018-14041 More information
moderate severity
Vulnerable versions: < 4.1.2
Patched version: 4.1.2
In Bootstrap before 4.1.2, XSS is possible in the data-target property of scrollspy. This is similar to CVE-2018-14042.